### PR TITLE
Add total server count in stats

### DIFF
--- a/cogs/stats/commands.py
+++ b/cogs/stats/commands.py
@@ -12,6 +12,8 @@ class StatsCommands(Stats):
     @commands.command()
     async def stats(self, ctx: Context):
         all_time = await self.bot.pool.fetchval("SELECT count(*) FROM messages")
+        server_count = len(self.bot.guilds)
+
         await ctx.send(
             embed=MEE6Embed.stats_embed(
                 self.msg_count,
@@ -20,6 +22,7 @@ class StatsCommands(Stats):
                 self.edit_count,
                 self.servers_joined,
                 self.servers_left,
+                server_count,
                 self.slanders_sent,
                 self.start_time,
                 self.bot.user.display_avatar.url if self.bot.user else "",

--- a/utils/embeds.py
+++ b/utils/embeds.py
@@ -74,19 +74,25 @@ class MEE6Embed(Embed):
 
     @staticmethod
     def stats_embed(
-        sent, all_time, deleted, edited, joined, left, slandered, started, icon_url
+        sent, all_time, deleted, edited, joined, left, total_servers, slandered, started, icon_url
     ):
         embed = Embed(
             description=f"Stats from the bot since <t:{started}:F>", color=Color.gold()
         )
         embed.set_author(name="Stats", icon_url=icon_url)
-        embed.add_field(name="Messages Seen", value=f"{sent:,}", inline=False)
-        embed.add_field(
-            name="All Time Messages Seen", value=f"{all_time:,}", inline=False
-        )
-        embed.add_field(name="Messages Deleted", value=f"{deleted:,}", inline=False)
-        embed.add_field(name="Messages Edited", value=f"{edited:,}", inline=False)
-        embed.add_field(name="Servers Joined", value=f"{joined:,}", inline=False)
-        embed.add_field(name="Servers Left", value=f"{left:,}", inline=False)
-        embed.add_field(name="Times Slandered", value=f"{slandered:,}", inline=False)
+
+        fields = { # All values are assumed to be numeric such that comma formatting will work.
+            "Messages Seen": sent,
+            "All Time Messages Seen": all_time,
+            "Messages Deleted": deleted,
+            "Messages Edited": edited,
+            "Servers Joined": joined,
+            "Servers Left": left,
+            "Total Servers": total_servers,
+            "Times Slandered": slandered
+        }
+
+        for name, value in fields.items():
+            embed.add_field(name=name, value=f"{value:,}", inline=False)
+
         return embed


### PR DESCRIPTION
Adds a "Total Servers" field to the stats embed showing the total number of servers the bot is in.